### PR TITLE
ability to dump elements in head and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ following optional features:
 - `entry` if specified, will add a `<script src={{entry}}>` element
 - `css` if specified will add a `<link rel="stylesheet" href={{css}}>` element
 - `favicon` if `true` the `favicon.ico` request [will be suppressed][1]
-- `head` if `[String]` the contents will be dumped `[<meta>].join('')` in the head
-- `body` if `[String]` the contents will be dumped `[<div>].join('')` in the body
+- `head` if `[String]` the contents will be dumped `['<meta>'].join('')` in the head
+- `body` if `[String]` the contents will be dumped `['<div>'].join('')` in the body
 
 ## Additional properties
 Combine `simple-html-index` with

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ following optional features:
 - `entry` if specified, will add a `<script src={{entry}}>` element
 - `css` if specified will add a `<link rel="stylesheet" href={{css}}>` element
 - `favicon` if `true` the `favicon.ico` request [will be suppressed][1]
+- `head` if `[String]` the contents will be dumped `[<meta>].join('')` in the head
+- `body` if `[String]` the contents will be dumped `[<div>].join('')` in the body
 
 ## Additional properties
 Combine `simple-html-index` with

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ following optional features:
 - `entry` if specified, will add a `<script src={{entry}}>` element
 - `css` if specified will add a `<link rel="stylesheet" href={{css}}>` element
 - `favicon` if `true` the `favicon.ico` request [will be suppressed][1]
-- `head` if `[String]` the contents will be dumped `['<meta>'].join('')` in the head
-- `body` if `[String]` the contents will be dumped `['<div>'].join('')` in the body
+- `head` if `String` the contents will be dumped in the head
+- `body` if `String` the contents will be dumped in the body
 
 ## Additional properties
 Combine `simple-html-index` with

--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ function createHtml (opt) {
     '<meta charset="utf-8">',
     opt.css ? ('<link rel="stylesheet" href="' + opt.css + '">') : '',
     opt.favicon ? favicon : '',
-    opt.head ? opt.head.join('') : '',
+    opt.head ? opt.head : '',
     '</head><body>',
     opt.entry ? ('<script src="' + opt.entry + '"></script>') : '',
-    opt.body ? opt.body.join('') : '',
+    opt.body ? opt.body : '',
     '</body>',
     '</html>'
   ].join(''))

--- a/index.js
+++ b/index.js
@@ -14,8 +14,10 @@ function createHtml (opt) {
     '<meta charset="utf-8">',
     opt.css ? ('<link rel="stylesheet" href="' + opt.css + '">') : '',
     opt.favicon ? favicon : '',
+    opt.head ? opt.head.join('') : '',
     '</head><body>',
     opt.entry ? ('<script src="' + opt.entry + '"></script>') : '',
+    opt.body ? opt.body.join('') : '',
     '</body>',
     '</html>'
   ].join(''))


### PR DESCRIPTION
I needed to add this `meta` tag to the head

```
<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1, user-scalable=no">
```

while using budo to serve my development bundle to my phone.

Thought it might be a useful feature for others as well.
