### PR TITLE
index: add missing h5bp tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = createHtml
 function createHtml (opt) {
   opt = opt || {}
   return fromString([
-    '<!doctype html>',
+    '<!DOCTYPE html>',
+    '<html lang="en-us">',
     '<head>',
     opt.title ? ('<title>' + opt.title + '</title>') : '',
     '<meta charset="utf-8">',


### PR DESCRIPTION
Allows media queries to work based on displayport width. And allows for most of
h5bp compat :sparkles: Thanks!
