### PR TITLE
add lang option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ following optional features:
 - `entry` if specified, will add a `<script src={{entry}}>` element
 - `css` if specified will add a `<link rel="stylesheet" href={{css}}>` element
 - `favicon` if `true` the `favicon.ico` request [will be suppressed][1]
+- `lang` if specified, will add a `<html lang={{lang}}>` element.
 
 ## Additional properties
 Combine `simple-html-index` with

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function createHtml (opt) {
   opt = opt || {}
   return fromString([
     '<!DOCTYPE html>',
-    '<html lang="en-us">',
+    '<html lang="' + (opt.lang ? opt.lang : "en") + '">',
     '<head>',
     opt.title ? ('<title>' + opt.title + '</title>') : '',
     '<meta charset="utf-8">',

--- a/test.js
+++ b/test.js
@@ -3,12 +3,13 @@ var html = require('./')
 var concat = require('concat-stream')
 
 test('should write html', function (t) {
-  t.plan(5)
-  run(t, undefined, '<!DOCTYPE html><html lang="en-us"><head><meta charset="utf-8"></head><body></body></html>')
-  run(t, { title: 'foo' }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"></head><body></body></html>')
-  run(t, { title: 'foo', entry: 'blah.js' }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"></head><body><script src="blah.js"></script></body></html>')
-  run(t, { title: 'foo', css: 'bla.css' }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"><link rel="stylesheet" href="bla.css"></head><body></body></html>')
-  run(t, { title: 'foo', favicon: true }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"><link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,"></head><body></body></html>')
+  t.plan(6)
+  run(t, undefined, '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"></head><body></body></html>')
+  run(t, { title: 'foo' }, '<!DOCTYPE html><html lang="en"><head><title>foo</title><meta charset="utf-8"></head><body></body></html>')
+  run(t, { title: 'foo', entry: 'blah.js' }, '<!DOCTYPE html><html lang="en"><head><title>foo</title><meta charset="utf-8"></head><body><script src="blah.js"></script></body></html>')
+  run(t, { title: 'foo', css: 'bla.css' }, '<!DOCTYPE html><html lang="en"><head><title>foo</title><meta charset="utf-8"><link rel="stylesheet" href="bla.css"></head><body></body></html>')
+  run(t, { title: 'foo', favicon: true }, '<!DOCTYPE html><html lang="en"><head><title>foo</title><meta charset="utf-8"><link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,"></head><body></body></html>')
+  run(t, { title: 'foo', favicon: true, lang: 'en-US' }, '<!DOCTYPE html><html lang="en-US"><head><title>foo</title><meta charset="utf-8"><link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,"></head><body></body></html>')
 })
 
 function run (t, opt, expected) {

--- a/test.js
+++ b/test.js
@@ -4,11 +4,11 @@ var concat = require('concat-stream')
 
 test('should write html', function (t) {
   t.plan(5)
-  run(t, undefined, '<!doctype html><head><meta charset="utf-8"></head><body></body></html>')
-  run(t, { title: 'foo' }, '<!doctype html><head><title>foo</title><meta charset="utf-8"></head><body></body></html>')
-  run(t, { title: 'foo', entry: 'blah.js' }, '<!doctype html><head><title>foo</title><meta charset="utf-8"></head><body><script src="blah.js"></script></body></html>')
-  run(t, { title: 'foo', css: 'bla.css' }, '<!doctype html><head><title>foo</title><meta charset="utf-8"><link rel="stylesheet" href="bla.css"></head><body></body></html>')
-  run(t, { title: 'foo', favicon: true }, '<!doctype html><head><title>foo</title><meta charset="utf-8"><link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,"></head><body></body></html>')
+  run(t, undefined, '<!DOCTYPE html><html lang="en-us"><head><meta charset="utf-8"></head><body></body></html>')
+  run(t, { title: 'foo' }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"></head><body></body></html>')
+  run(t, { title: 'foo', entry: 'blah.js' }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"></head><body><script src="blah.js"></script></body></html>')
+  run(t, { title: 'foo', css: 'bla.css' }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"><link rel="stylesheet" href="bla.css"></head><body></body></html>')
+  run(t, { title: 'foo', favicon: true }, '<!DOCTYPE html><html lang="en-us"><head><title>foo</title><meta charset="utf-8"><link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,"></head><body></body></html>')
 })
 
 function run (t, opt, expected) {


### PR DESCRIPTION
1. add html tags & toUpperCase(doctype) on test to fix test failure.
2. add lang option: default  `<html>`, optional `<html lang="xxx">` 

e.g.
`html({ title: 'こんにちは！😀', lang: 'ja' })`
